### PR TITLE
Data tagging - Suggested by @SecurityWard

### DIFF
--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -16,6 +16,7 @@ processor_arguments:
     b64: {}
     gzip: {}
     hex: {}
+tags: []
 failure_response: Failed
 success_response: Received
 log_format_template:
@@ -45,6 +46,7 @@ A description of each option is as follows:
 | `port` | The Port to bind to on the host |
 | `process_list` | The modules, in processing order, to use for processing payloads |
 | `processor_arguments` | This is where you can ovveride the parameters specified in Processor Modules, as Processors are populated, so are the parameters they specify in the `--dump-config` option. |
+| `tags` | Specify tags to be applied to data captured during the runtime session. Be sure to remove tags between different sessions if you do not want them to be applied to new data. Sessions which have tags applied to them will save files in the configured `upload_dir` in a new directory named by joining tags with a `-` character | 
 | `failure_response` | The response to send to clients on a failed request. This is a [Jinja Template](https://jinja.palletsprojects.com/en/3.0.x/) | 
 | `success_response` | The response to send to clients on a successful request. This is a [Jinja Template](https://jinja.palletsprojects.com/en/3.0.x/) | 
 | `log_format_template` | These are how messages are displayed in the console, each child item in the default configuration can be changed to display data in a way that suits you best. <br>`initial_request` is displayed first, see the options avaialble for display in [`app.py`](https://github.com/cyberbutler/RedDrop/tree/master/reddrop/app.py).<br>`data_received` is displayed when a request parameter is received and for each subsequent parameter in each request. See the return dict in [`request_processing.py`](https://github.com/cyberbutler/RedDrop/tree/master/reddrop/request_processing.py) for display fields. <br>`file_uploaded` is displayed when a file is uploaded. See the return dict in [`file_processing.py`](https://github.com/cyberbutler/RedDrop/tree/master/reddrop/file_processing.py) for display fields.

--- a/reddrop/app.py
+++ b/reddrop/app.py
@@ -40,6 +40,7 @@ def processRequest(path):
         "remote_addr": request.remote_addr,
         "src": src_ip,
         "method": request.method,
+        "tags": config['tags'].get(),
         "path": path,
         "files": [],
         "headers": dict(request.headers),

--- a/reddrop/args.py
+++ b/reddrop/args.py
@@ -70,12 +70,12 @@ def parse_arguments():
         formatter_class=CustomArgumentFormatter
     )
     args.add_argument(
-        '--host', '-H', 
+        '-H', '--host', 
         help="The host IP Address to bind to", 
         default="0.0.0.0"
     )
     args.add_argument(
-        '--port', '-P', 
+        '-P','--port',
         help="The port to bind to", 
         default=80, 
         type=int
@@ -111,7 +111,7 @@ def parse_arguments():
         action=argparse.BooleanOptionalAction
     )
     args.add_argument(
-        '--auto-extract-tar', '-x',
+        '-x','--auto-extract-tar',
         help='Auto extract TAR archives received by the server.',
         action='store_true',
         default=False
@@ -126,6 +126,12 @@ def parse_arguments():
         '-r', '--authorization_rules',
         help="Specify an Authorization Rule to deny requests which do not match the provided Key and Regex value pair. Specified as <Key>=<Regex>.",
         action=ParseKeyValue
+    )
+    args.add_argument(
+        '-t', '--tag',
+        help='Tag data received during this session in the logs as well as the directory files are uploaded to. Example: -t log4j -t acme.org',
+        action='append',
+        dest='tags'
     )
 
     return args.parse_args()

--- a/reddrop/config.py
+++ b/reddrop/config.py
@@ -67,6 +67,11 @@ config['failure_response'] = (
 # ```
 config['authorization_rules'] = []
 
+
+# Specify tags to be applied to data captured during the runtime session
+# Be sure to remove tags between different sessions if you do not want them to be applied to new data.
+config['tags'] = []
+
 # Confused Configuration Template for validating user provided configuration options
 ConfigTemplate = {
     'authorization_rules': confuse.Sequence({

--- a/reddrop/file_processing.py
+++ b/reddrop/file_processing.py
@@ -95,7 +95,11 @@ def processFile(parameter:str, f:FileStorage, src_ip:str, processing_list=[]):
     This function will process and extract tar archive files passed to it given a set of configuration options.
     """
 
-    fileDir = os.path.join(os.path.abspath(config['upload_dir'].get()), secure_filename(src_ip))
+    fileDir = os.path.join(
+        os.path.abspath(config['upload_dir'].get()), 
+        secure_filename('-'.join(config['tags'].get())),
+        secure_filename(src_ip)
+    )
 
     if not os.path.exists(fileDir):
         os.makedirs(fileDir)


### PR DESCRIPTION
@SecurityWard suggested adding Data Tagging for filtering logs and files at a later time. This PR adds functionality where Tags are applied to each request which passes any authorization rules (when specified). In the case of file upload, a new directory will be created under the configured `upload_dir` with a name of each tag joined by a `-` character. 

Example:
![image](https://user-images.githubusercontent.com/46307021/160007594-6b890a87-e74c-49d8-85d2-b0982911f6e9.png)
 