### PR TITLE
Changed Production Server to Gunicorn for TLS Support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ flask = "*"
 python-json-logger = "*"
 pycrypto = "*"
 confuse = "*"
-waitress = "*"
+gunicorn = "*"
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ optional arguments:
                         <Key>=<Regex>. (default: None)
   -t TAGS, --tag TAGS   Tag data received during this session in the logs as well as the directory files are uploaded to. Example:
                         -t log4j -t acme.org (default: None)
+  --tls-keyfile GUNICORN.KEYFILE
+                        Enables TLS Support. (Production Only) The path to a TLS key file (default: None)
+  --tls-certfile GUNICORN.CERTFILE
+                        Enables TLS Support. (Production Only) The path to a TLS cert file (default: None)
 
 Far more configuration options exist which must be specified in Environment Variables, use `--dump-config` to see all of the options
 

--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -16,6 +16,10 @@ processor_arguments:
     b64: {}
     gzip: {}
     hex: {}
+gunicorn:
+    defaults:
+        bind: 0.0.0.0:80
+        workers: <Dependent on Your CPUs>
 tags: []
 failure_response: Failed
 success_response: Received
@@ -46,6 +50,7 @@ A description of each option is as follows:
 | `port` | The Port to bind to on the host |
 | `process_list` | The modules, in processing order, to use for processing payloads |
 | `processor_arguments` | This is where you can ovveride the parameters specified in Processor Modules, as Processors are populated, so are the parameters they specify in the `--dump-config` option. |
+| `gunicorn` | Options passed to the Gunicorn Production Web Server, see [the settings documentation](https://docs.gunicorn.org/en/stable/settings.html) for all options |
 | `tags` | Specify tags to be applied to data captured during the runtime session. Be sure to remove tags between different sessions if you do not want them to be applied to new data. Sessions which have tags applied to them will save files in the configured `upload_dir` in a new directory named by joining tags with a `-` character | 
 | `failure_response` | The response to send to clients on a failed request. This is a [Jinja Template](https://jinja.palletsprojects.com/en/3.0.x/) | 
 | `success_response` | The response to send to clients on a successful request. This is a [Jinja Template](https://jinja.palletsprojects.com/en/3.0.x/) | 

--- a/reddrop/app.py
+++ b/reddrop/app.py
@@ -55,7 +55,7 @@ def processRequest(path):
 
     try:
         request_parameters = {}
-        if request.json is not None:
+        if request.is_json:
             request_parameters.update(request.json)
 
         if len(request.data) and not request.is_json:

--- a/reddrop/args.py
+++ b/reddrop/args.py
@@ -133,5 +133,15 @@ def parse_arguments():
         action='append',
         dest='tags'
     )
+    args.add_argument(
+        '--tls-keyfile',
+        help='Enables TLS Support. (Production Only) The path to a TLS key file',
+        dest='gunicorn.keyfile'
+    )
+    args.add_argument(
+        '--tls-certfile',
+        help='Enables TLS Support. (Production Only) The path to a TLS cert file',
+        dest='gunicorn.certfile'
+    )
 
     return args.parse_args()

--- a/reddrop/config.py
+++ b/reddrop/config.py
@@ -1,3 +1,5 @@
+import multiprocessing
+
 import confuse
 
 config = confuse.Configuration('RedDrop', __name__)
@@ -71,6 +73,13 @@ config['authorization_rules'] = []
 # Specify tags to be applied to data captured during the runtime session
 # Be sure to remove tags between different sessions if you do not want them to be applied to new data.
 config['tags'] = []
+
+# Settings for the Production Gunicorn Server
+# See https://docs.gunicorn.org/en/stable/settings.html for available options.
+config['gunicorn']['defaults'] = {
+    'bind': f"{config['host'].get()}:{config['port'].get()}",
+    'workers': (multiprocessing.cpu_count() * 2) + 1
+}
 
 # Confused Configuration Template for validating user provided configuration options
 ConfigTemplate = {


### PR DESCRIPTION
Waitress does not offer TLS support out of the box, and to avoid users having to set up their own Reverse Proxy, I decided to instead change the production server to gunicorn. 